### PR TITLE
Feature/sign notarize macos binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
       - name: Set up Gon
         run: brew tap mitchellh/gon && brew install mitchellh/gon/gon
       - name: Import Keychain Certs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,23 +7,28 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
-      -
-        name: Run GoReleaser
+      - name: Set up Gon
+        run: brew tap mitchellh/gon && brew install mitchellh/gon/gon
+      - name: Import Keychain Certs
+        uses: apple-actions/import-codesign-certs@v1
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}

--- a/.gon-amd64.json
+++ b/.gon-amd64.json
@@ -1,0 +1,15 @@
+{
+  "source" : ["./dist/macos-amd64_darwin_amd64/secrets-cli"],
+  "bundle_id" : "com.madwire.secrets-cli",
+  "apple_id": {
+    "username" : "chris.meyers@madwire.com",
+    "password":  "@env:AC_PASSWORD"
+  },
+  "sign" :{
+    "application_identity" : "Developer ID Application: Madwire Media LLC (5J7CLBVDUV)"
+  },
+  "dmg" :{
+    "output_path":  "./dist/secrets-cli-macos-amd64.dmg",
+    "volume_name":  "secrets-cli"
+  }
+}

--- a/.gon-arm64.json
+++ b/.gon-arm64.json
@@ -1,0 +1,15 @@
+{
+  "source" : ["./dist/macos-arm64_darwin_arm64/secrets-cli"],
+  "bundle_id" : "com.madwire.secrets-cli",
+  "apple_id": {
+    "username" : "chris.meyers@madwire.com",
+    "password":  "@env:AC_PASSWORD"
+  },
+  "sign" :{
+    "application_identity" : "Developer ID Application: Madwire Media LLC (5J7CLBVDUV)"
+  },
+  "dmg" :{
+    "output_path":  "./dist/secrets-cli-macos-arm64.dmg",
+    "volume_name":  "secrets-cli"
+  }
+}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,22 @@ builds:
       post:
         - gon .gon-amd64.json
         - mv dist/secrets-cli-macos-amd64.dmg dist/secrets-cli_{{ .Version }}_darwin_amd64.dmg
+  - binary: secrets-cli
+    id: macos-arm64
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/madwire-media/secrets-cli/vars.BuildVersion={{ .Version }}
+      - -X github.com/madwire-media/secrets-cli/vars.BuildCommit={{ .Commit }}
+    hooks:
+      post:
+        - gon .gon-arm64.json
+        - mv dist/secrets-cli-macos-arm64.dmg dist/secrets-cli_{{ .Version }}_darwin_arm64.dmg
 archives:
   - id: linux-archive
     builds:
@@ -61,6 +77,7 @@ archives:
   - id: darwin-archive
     builds:
       - macos-amd64
+      - macos-arm64
     format: tar.gz
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     files:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,28 +7,74 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - binary: secrets-cli
+    id: linux
     goos:
       - linux
-      - windows
-      - darwin
+    env:
+      - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/madwire-media/secrets-cli/vars.BuildVersion={{.Version}}
-      - -X github.com/madwire-media/secrets-cli/vars.BuildCommit={{.Commit}}
-    binary: secrets
+      - -X github.com/madwire-media/secrets-cli/vars.BuildVersion={{ .Version }}
+      - -X github.com/madwire-media/secrets-cli/vars.BuildCommit={{ .Commit }}
+  - binary: secrets-cli
+    id: windows
+    goos:
+      - windows
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/madwire-media/secrets-cli/vars.BuildVersion={{ .Version }}
+      - -X github.com/madwire-media/secrets-cli/vars.BuildCommit={{ .Commit }}
+  - binary: secrets-cli
+    id: macos-amd64
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/madwire-media/secrets-cli/vars.BuildVersion={{ .Version }}
+      - -X github.com/madwire-media/secrets-cli/vars.BuildCommit={{ .Commit }}
+    hooks:
+      post:
+        - gon .gon-amd64.json
+        - mv dist/secrets-cli-macos-amd64.dmg dist/secrets-cli_{{ .Version }}_darwin_amd64.dmg
 archives:
-  # - replacements:
-  #     darwin: Darwin
-  #     linux: Linux
-  #     windows: Windows
-  #     386: i386
-  #     amd64: x86_64
+  - id: linux-archive
+    builds:
+      - linux
+    format: tar.gz
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    files:
+      - none*
+  - id: windows-archive
+    builds:
+      - windows
+    format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    files:
+      - none*
+  - id: darwin-archive
+    builds:
+      - macos-amd64
+    format: tar.gz
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    files:
+      - none*
+release:
+  ids:
+    - linux-archive
+    - windows-archive
+  extra_files:
+    - glob: ./dist/*.dmg
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: '{{ .Tag }}-next'
 changelog:
   sort: asc
   filters:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/madwire-media/secrets-cli
 
-go 1.15
+go 1.17
 
 require (
 	github.com/hashicorp/vault-plugin-auth-jwt v0.9.4
@@ -13,4 +13,55 @@ require (
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	cloud.google.com/go v0.56.0 // indirect
+	github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 // indirect
+	github.com/coreos/go-oidc/v3 v3.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.11.0 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.3.5 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/cap v0.1.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-hclog v0.16.1 // indirect
+	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/go-kms-wrapping/entropy v0.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-plugin v1.0.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.6.2 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.1 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/go-version v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/mitchellh/pointerstructure v1.0.0 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
+	go.opencensus.io v0.22.3 // indirect
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
+	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/api v0.29.0 // indirect
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940 // indirect
+	google.golang.org/grpc v1.28.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )


### PR DESCRIPTION
Adds signing and notarization to macOS binaries and adds Apple silicon support (arm64)

I don't have permission to add secrets to this repo. The following variables need to be added before triggering the GitHub action: `CERTIFICATES_P12`, `CERTIFICATES_P12_PASSWORD`, `AC_PASSWORD`